### PR TITLE
fix option buttons in dark color scheme

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -239,6 +239,7 @@ body {
   --text-muted-rgb: var(--the-color-rgb);
   --text-faint: var(--the-color);
   --text-on-accent: var(--the-color);
+  --text-on-accent-inverted: var(--the-color);
   --interactive-normal: var(--the-background-color);
   --interactive-hover: var(--the-background-color);
   --interactive-accent: var(--the-background-color);


### PR DESCRIPTION
When in dark color scheme, some buttons in the options panel have black text on black background, e.g. the "Manage" button in the themes section.